### PR TITLE
Create table - Duplicated SQL

### DIFF
--- a/Library/Phalcon/Migrations.php
+++ b/Library/Phalcon/Migrations.php
@@ -800,9 +800,7 @@ class " . $className . " extends Migration\n" .
                     $sqlInstructions = explode(';', $rawSql);
                     foreach ($sqlInstructions as $instruction) {
                         if ($instruction !== "" && strpos($instruction, '_pkey" ON') === false) {
-                            if ($rawSql !== '') {
-                                $sql[] = '$this->' . $dbAdapter . '->execute(\'' . $rawSql . '\');';
-                            }
+                            $sql[] = '$this->' . $dbAdapter . '->execute(\'' . $instruction . '\');';
                         }
                     }
                 } else {


### PR DESCRIPTION
Create table SQL is duplicated as many times as $sqlInstructions array count. We should add $instruction not $rawSql to $sql array.
Also remove unnecessary check " $rawSql !== '' " as we checked (above) that " $instruction !== '' " which is part of $rawSql